### PR TITLE
chore(deps): upgrade all dependencies

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,7 @@ const moment = require('moment');
 const syntaxhighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const markdownIt = require('markdown-it');
 const markdownItAnchor = require('markdown-it-anchor');
-const pluginRss = require('@11ty/eleventy-plugin-rss');
+const pluginRss = require('@11ty/eleventy-plugin-rss').default;
 const striptags = require('striptags');
 // const upgradeHelper = require('@11ty/eleventy-upgrade-help');
 

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -19,7 +19,7 @@ jobs:
       - run: npm run playwright:install
       - run: npm test
       - name: Publish test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -19,7 +19,7 @@ jobs:
       - run: npm run playwright:install
       - run: npm test
       - name: Publish test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 _site
 .DS_Store
 *.log
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,16 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
-        "@11ty/eleventy-plugin-rss": "^1.2.0",
+        "@11ty/eleventy-plugin-rss": "^3.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
-        "@fortawesome/fontawesome-free": "^6.4.2",
+        "@fortawesome/fontawesome-free": "^7.2.0",
         "@playwright/test": "^1.39.0",
         "@types/node": "^24.5.2",
         "bulma": "^1.0.0",
         "gh-pages": "^6.0.0",
         "markdown-it-anchor": "^9.0.0",
         "moment": "^2.29.4",
-        "npm-check-updates": "^17.0.0",
+        "npm-check-updates": "^22.2.1",
         "sass": "^1.69.3"
       }
     },
@@ -150,14 +150,16 @@
       }
     },
     "node_modules/@11ty/eleventy-plugin-rss": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
-      "integrity": "sha512-YzFnSH/5pObcFnqZ2sAQ782WmpOZHj1+xB9ydY/0j7BZ2jUNahn53VmwCB/sBRwXA/Fbwwj90q1MLo01Ru0UaQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-3.0.0.tgz",
+      "integrity": "sha512-kKW4DcR57xAyRx0e8gNhKh56ahHVEaAj8/TuXQDnw+B46ig2bWADJAlyj/GdV37IG5ja9dZ4SgKZrs/CHz6YWQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
-        "posthtml": "^0.16.6",
-        "posthtml-urls": "1.0.0"
+        "@11ty/eleventy-utils": "^2.0.7",
+        "@11ty/posthtml-urls": "^1.0.2",
+        "debug": "^4.4.3",
+        "posthtml": "^0.16.7"
       },
       "funding": {
         "type": "opencollective",
@@ -292,10 +294,11 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
+      "integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
       "dev": true,
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"
       }
@@ -742,12 +745,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/any-promise": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
-      "integrity": "sha512-lqzY9o+BbeGHRCOyxQkt/Tgvz0IZhTmQiA+LxQW8wSNpcTbj8K+0cZiSEvbpNZZP9/11Gy7dnLO3GNWUXO4d1g==",
-      "dev": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -1432,15 +1429,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/http-equiv-refresh": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-1.0.0.tgz",
-      "integrity": "sha512-TScO04soylRN9i/QdOdgZyhydXg9z6XdaGzEyOgDKycePeDeTT4KvigjBcI+tgfTlieLWauGORMq5F1eIDa+1w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1891,9 +1879,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.18",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.18.tgz",
-      "integrity": "sha512-bkUy2g4v1i+3FeUf5fXMLbxmV95eG4/sS7lYE32GrUeVgQRfQEk39gpskksFunyaxQgTIdrvYbnuNbO/pSUSqw==",
+      "version": "22.2.1",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.1.tgz",
+      "integrity": "sha512-mGdIJfhtg+q0BzhbOpbOL73zhMZlgBQMG4wnBwPMMD5k96028UCuV0753YeSYk9odoh7HWK6/cY69bWxT7o+yg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1901,8 +1889,8 @@
         "npm-check-updates": "build/cli.js"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0",
-        "npm": ">=8.12.1"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/nunjucks": {
@@ -2175,21 +2163,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/posthtml-urls": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-urls/-/posthtml-urls-1.0.0.tgz",
-      "integrity": "sha512-CMJ0L009sGQVUuYM/g6WJdscsq6ooAwhUuF6CDlYPMLxKp2rmCYVebEU+wZGxnQstGJhZPMvXsRhtqekILd5/w==",
-      "dev": true,
-      "dependencies": {
-        "http-equiv-refresh": "^1.0.0",
-        "list-to-array": "^1.1.0",
-        "parse-srcset": "^1.0.2",
-        "promise-each": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -2198,15 +2171,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/promise-each": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
-      "integrity": "sha512-67roqt1k3QDA41DZ8xi0V+rF3GoaMiX7QilbXu0vXimut+9RcKBNZ/t60xCRgcsihmNUsEjh48xLfNqOrKblUg==",
-      "dev": true,
-      "dependencies": {
-        "any-promise": "^0.1.0"
       }
     },
     "node_modules/prr": {

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.1.2",
-    "@11ty/eleventy-plugin-rss": "^1.2.0",
+    "@11ty/eleventy-plugin-rss": "^3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
-    "@fortawesome/fontawesome-free": "^6.4.2",
+    "@fortawesome/fontawesome-free": "^7.2.0",
     "@playwright/test": "^1.39.0",
     "@types/node": "^24.5.2",
     "bulma": "^1.0.0",
     "gh-pages": "^6.0.0",
     "markdown-it-anchor": "^9.0.0",
     "moment": "^2.29.4",
-    "npm-check-updates": "^17.0.0",
+    "npm-check-updates": "^22.2.1",
     "sass": "^1.69.3"
   },
   "scripts": {


### PR DESCRIPTION
Consolidates all open Renovate dependency upgrade PRs into one:\n\n- @11ty/eleventy-plugin-rss: ^1.2.0 → ^3.0.0 (ESM: fix `require()` with `.default`)\n- npm-check-updates: ^17.0.0 → ^22.2.1\n- @fortawesome/fontawesome-free: ^6.4.2 → ^7.2.0\n- actions/checkout: v4 → v6\n- actions/setup-node: v4 → v6\n- actions/upload-artifact: v4 → v7\n\nCloses #151, #144, #75, #114, #105, #99, #83